### PR TITLE
feat(api): centralize environment configuration

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import List, Optional, Set
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+DOCS_DIR: str = os.getenv("DOCS_DIR", "/app/docs")
+KB_DB_PATH: str = os.getenv("KB_DB_PATH", "/app/data/kb.sqlite")
+COLLECTION_NAME: str = os.getenv("COLLECTION_NAME", "gamefantasy")
+PERSIST_DIR: str = os.getenv("PERSIST_DIR", "./vector_store")
+EMBEDDING_MODEL: str = os.getenv("EMBEDDING_MODEL", "sentence-transformers/all-MiniLM-L6-v2")
+API_KEY_ENV: str = os.getenv("API_KEY", "changeme")
+READONLY_MODE: bool = os.getenv("READONLY_MODE", "false").lower() == "true"
+DEFAULT_LANGUAGE: str = os.getenv("DEFAULT_LANGUAGE", "zh-tw")
+FILTER_META_DEFAULT: bool = os.getenv("FILTER_META_DEFAULT", "true").lower() == "true"
+
+OPENAI_MODEL: str = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+OPENAI_API_KEY: Optional[str] = os.getenv("OPENAI_API_KEY")
+
+OLLAMA_MODEL: str = os.getenv("OLLAMA_MODEL", "llama3:latest")
+OLLAMA_HOST: str = os.getenv("OLLAMA_HOST", "http://localhost:11434")
+OLLAMA_USE_CHAT: bool = os.getenv("OLLAMA_USE_CHAT", "true").lower() == "true"
+
+MODEL_PRIORITY: List[str] = [x.strip() for x in os.getenv("MODEL_PRIORITY", "ollama,openai").split(",") if x.strip()]
+MAX_CONTEXT_CHARS: int = int(os.getenv("MAX_CONTEXT_CHARS", "6000"))
+DB_PATH: str = os.getenv("CONV_DB_PATH", "/app/data/conversations.db")
+META_TAGS: Set[str] = {"schema", "prompt", "config", "system", "curator", "meta"}
+HALF_LIFE_DAYS: int = int(os.getenv("RECENCY_HALF_LIFE_DAYS", "45"))
+RERANK_MODEL: str = os.getenv("RERANK_MODEL", "cross-encoder/ms-marco-MiniLM-L-6-v2")
+
+# Ensure database directory exists
+Path(DB_PATH).parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,11 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from api.config import DOCS_DIR, OPENAI_MODEL
+
+
+def test_defaults_are_strings():
+    assert isinstance(DOCS_DIR, str)
+    assert isinstance(OPENAI_MODEL, str)


### PR DESCRIPTION
## Summary
- extract environment configuration into new `api.config` module with typed constants
- update API to import configuration values instead of defining them inline
- add basic test verifying config exports

## Testing
- `python -m py_compile api/config.py api/app.py tests/test_config.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b01502a35c83219e7ed84a9ed3eadc