### PR TITLE
Add French language policy and normalize language codes

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -365,6 +365,9 @@ def _language_policy(lang: Optional[str]) -> tuple[str, str]:
     if l == "ko":
         return ("【언어 규칙】오직 한국어로만 답변하세요. 고유명사는 영어 표기를 허용하지만, 완전한 영어 문장은 만들지 마세요. 영어 인용은 한국어로 요약하세요. 코드/명령은 영어 가능하나 설명은 반드시 한국어로 작성하세요.",
                 "언어 규칙을 엄격히 준수: 한국어만 사용. 영어 문장 출력 금지. 고유명사 영어 표기는 허용하되 문장 금지. 인용은 한국어로 요약.")
+    if l == "fr":
+        return ("【Règles linguistiques】Utilisez uniquement le français ; les noms propres anglais peuvent rester mais ne formez pas de phrases complètes en anglais ; toute citation en anglais doit être reformulée en français ; le code/commande peut être en anglais mais les explications doivent être en français.",
+                "Respectez strictement les règles linguistiques : utilisez uniquement le français ; n'écrivez aucune phrase en anglais ; reformulez les citations anglaises en français.")
     if l == "en":
         return ("Use ONLY English. Proper nouns may remain in their original form. Summarize quotations in English. Code/commands may be English; explanatory text must be English.",
                 "Strictly use English only. No sentences in other languages. Proper nouns allowed; quotes must be summarized in English.")

--- a/web/index.html
+++ b/web/index.html
@@ -22,7 +22,7 @@
     <main class="main">
       <div class="header">
         <div class="pill">模型：<code id="modelLabel">(server env)</code></div>
-        <div class="pill">語言：<code id="langLabel">zh-TW</code></div>
+          <div class="pill">語言：<code id="langLabel">zh-tw</code></div>
         <div class="pill">RAG：<span id="ragState">關</span></div>
         <button class="ghost" id="toggleRight">顯示/隱藏右側面板</button>
         <div class="pill" title="版本">v: chat-params-rag-right-2025-08-24</div>
@@ -63,7 +63,7 @@
           <h3>生成參數</h3>
           <div class="grid2">
             <div class="row"><label>模式</label><select id="modeSel"><option value="strict">strict（嚴謹）</option><option value="creative" selected>creative（創作）</option></select></div>
-            <div class="row"><label>語言</label><select id="langSel"><option value="zh-TW" selected>繁體中文</option><option value="zh-CN">简体中文</option><option value="en">English</option><option value="ja">日本語</option><option value="ko">한국어</option><option value="fr">Français</option></select></div>
+            <div class="row"><label>語言</label><select id="langSel"><option value="zh-tw" selected>繁體中文</option><option value="zh-cn">简体中文</option><option value="en">English</option><option value="ja">日本語</option><option value="ko">한국어</option><option value="fr">Français</option></select></div>
             <div class="row"><label>引擎</label><select id="engineSel"><option value="auto" selected>auto（服務端決定）</option><option value="ollama">ollama（本地）</option><option value="openai">openai（雲端）</option></select></div>
             <div class="row"><label>目標字數（可選）</label><input id="lenInput" type="text" placeholder='如 "500-700" 或 "800"' /></div>
             <div class="row"><label>Thread ID（可留空）</label><input id="threadInput" type="text" placeholder="自動產生" /></div>

--- a/web/main.js
+++ b/web/main.js
@@ -104,7 +104,7 @@ hedRange.onchange = () => { params.hedging   = parseFloat(hedRange.value); saveP
 forRange.onchange = () => { params.formality = parseFloat(forRange.value); saveParams(); };
 
 saveParamsBtn.onclick = saveParams;
-resetParamsBtn.onclick = () => { Object.assign(params, { apiBase:'', apiKey:'', mode:'creative', lang:'zh-TW', engine:'auto', targetLength:'', threadId:'', k:6, rerank:true, namespace:'', canonicality:'' }); saveParams(); location.reload(); };
+ resetParamsBtn.onclick = () => { Object.assign(params, { apiBase:'', apiKey:'', mode:'creative', lang:'zh-tw', engine:'auto', targetLength:'', threadId:'', k:6, rerank:true, namespace:'', canonicality:'' }); saveParams(); location.reload(); };
 
 pingBtn.onclick = async () => {
   healthTxt.textContent = '檢查中…';

--- a/web/params.js
+++ b/web/params.js
@@ -2,7 +2,7 @@ export const params = {
   apiBase: localStorage.getItem('apiBase') || '',
   apiKey: localStorage.getItem('apiKey') || '',
   mode: localStorage.getItem('mode') || 'creative',
-  lang: localStorage.getItem('lang') || 'zh-TW',
+  lang: localStorage.getItem('lang') || 'zh-tw',
   engine: localStorage.getItem('engine') || 'auto',
   targetLength: localStorage.getItem('targetLength') || '',
   threadId: localStorage.getItem('threadId') || '',


### PR DESCRIPTION
## Summary
- Enforce French-only responses in `_language_policy`.
- Normalize front-end language codes to match backend `_norm_lang` mapping.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b45d46d4208321a9cf8640564b793b