### PR TITLE
fix: enforce language rules in East Asian templates

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -391,15 +391,15 @@ _USER_CONTENT_TEMPLATES = {
     },
     "zh-cn": {
         "guide": "字数约 {target_length}。",
-        "body": "请根据上述内容完成“{query}”。{guide}\n输出可以使用段落或项目符号。",
+        "body": "请根据上述内容完成“{query}”。{guide}\n输出可以使用段落或项目符号，务必遵守语言规则。",
     },
     "ja": {
         "guide": "目安の長さ: {target_length}。",
-        "body": "上記の内容に基づいて「{query}」を完成してください。{guide}\n段落または箇条書き可。",
+        "body": "上記の内容に基づいて「{query}」を完成してください。{guide}\n段落または箇条書き可。言語ルールを必ず守ってください。",
     },
     "ko": {
-        "guide": " 분량: 약 {target_length}.",
-        "body": "위 내용을 바탕으로 ‘{query}’를 완성하세요.{guide}\n단락 또는 불릿 허용.",
+        "guide": " 분량: 약 {target_length}자.",
+        "body": "위 내용을 바탕으로 ‘{query}’를 완성하세요.{guide}\n단락 또는 불릿 허용. 언어 규칙을 반드시 준수하세요.",
     },
     "fr": {
         "guide": " Longueur cible : {target_length}.",


### PR DESCRIPTION
## Summary
- ensure zh-CN, ja, and ko user content templates explicitly remind the model to obey language rules
- add missing character unit in Korean target length hint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b45b551b1c83219f0796d6f693067b