### PR TITLE
Show loader for pending assistant messages

### DIFF
--- a/web/chat.js
+++ b/web/chat.js
@@ -3,10 +3,17 @@ import { store } from './storage.js';
 export function appendBubble(role, content){
   const chatEl = document.getElementById('chat');
   const wrap = document.createElement('div');
-  wrap.className = `msg ${role}`;
+  const pending = role === 'assistant' && !content;
+  wrap.className = `msg ${role}${pending ? ' pending' : ''}`;
   wrap.innerHTML = `<div class="role">${role}</div><div class="content"></div>`;
-  wrap.querySelector('.content').textContent = content;
+  const contentEl = wrap.querySelector('.content');
+  if(pending){
+    contentEl.innerHTML = '<span class="loader" aria-label="thinking"></span>';
+  }else{
+    contentEl.textContent = content;
+  }
   chatEl.appendChild(wrap);
+  return wrap;
 }
 
 export function renderAll(){

--- a/web/main.js
+++ b/web/main.js
@@ -231,7 +231,7 @@ function escapeHtml(s){ return s.replace(/[&<>]/g, c=>({"&":"&amp;","<":"&lt;","
 
 // ====== 發送與串流 ======
 async function send(){ const text = inputEl.value.trim(); if(!text && !(store.ragEnabled && selected.size>0)) return; inputEl.value = '';
-  const sess = sessions[store.currentId]; if(text) { sess.messages.push({role:'user', content:text}); appendBubble('user', text); } persist(); const assistant = { role:'assistant', content:'' }; sess.messages.push(assistant); persist(); const bubble = document.createElement('div'); bubble.className = 'msg assistant pending'; bubble.innerHTML = `<div class=\"role\">assistant<\/div><div class=\"content\"><span class=\"loader\" aria-label=\"thinking\"><\/span><\/div>`; const contentEl = bubble.querySelector('.content');
+  const sess = sessions[store.currentId]; if(text) { sess.messages.push({role:'user', content:text}); appendBubble('user', text); } persist(); const assistant = { role:'assistant', content:'' }; sess.messages.push(assistant); persist(); const bubble = appendBubble('assistant', ''); const contentEl = bubble.querySelector('.content');
   // 在這一輪對話綁定停止鍵，能移除等待動畫
   let gotAny = false;
   const prevStopHandler = stopBtn.onclick;
@@ -245,7 +245,7 @@ async function send(){ const text = inputEl.value.trim(); if(!text && !(store.ra
     }
     // 還原舊的 handler，避免影響下一輪
     setTimeout(()=>{ stopBtn.onclick = prevStopHandler; }, 0);
-  }; chatEl.appendChild(bubble); chatEl.scrollTop = chatEl.scrollHeight;
+  }; chatEl.scrollTop = chatEl.scrollHeight;
   const payload = buildPayload(sess.messages, text);
   controller = new AbortController(); sendBtn.disabled = true; stopBtn.disabled = false; try{
     const res = await fetch(getApiBase()+ '/compose_stream', { method:'POST', headers:{ 'Content-Type':'application/json', 'Accept':'text/event-stream, text/plain', ...buildHeaders() }, body: JSON.stringify(payload), signal: controller.signal });


### PR DESCRIPTION
## Summary
- Render a loading spinner for assistant bubbles without content and mark them as pending.
- Use `appendBubble` for assistant placeholders so all rendering paths share loader behavior.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5ae3a62348321a75ee4b8b4e94c51