### PR TITLE
Restore assistant typing animation and reasoning placement

### DIFF
--- a/web/chat.js
+++ b/web/chat.js
@@ -32,11 +32,9 @@ export function appendReasoning(node, text){
   }
   const pre = block.querySelector('pre');
   pre.textContent += text;
-  if(node._textNode){
-    node.insertBefore(block, node._textNode);
-  }else{
-    node.prepend(block);
-  }
+  // Ensure reasoning block is always displayed above the generated content
+  // regardless of whether a text node already exists.
+  node.prepend(block);
 }
 
 export function renderAll(){

--- a/web/main.js
+++ b/web/main.js
@@ -257,11 +257,19 @@ async function send(){ const text = inputEl.value.trim(); if(!text && !(store.ra
         if(dataStr==='[DONE]') return;
         let obj;
         try{ obj = JSON.parse(dataStr); }
+        catch{ obj = { data: dataStr }; }
+        if(typeof obj.data === 'string' && (obj.type === 'text' || !obj.type)){
+          assistant.content += obj.data;
+          contentEl._textNode.textContent = assistant.content;
+          bubble.classList.remove('pending');
           chatEl.scrollTop = chatEl.scrollHeight;
           persist();
         }else if(obj.type === 'reasoning'){
           appendReasoning(contentEl, obj.data);
         }else if(typeof obj.token === 'string'){
+          assistant.content += obj.token;
+          contentEl._textNode.textContent = assistant.content;
+          bubble.classList.remove('pending');
           chatEl.scrollTop = chatEl.scrollHeight;
           persist();
         }
@@ -273,6 +281,7 @@ async function send(){ const text = inputEl.value.trim(); if(!text && !(store.ra
           const url = new URL(location.href);
           url.searchParams.set('threadId', obj.thread_id);
           history.replaceState(null, '', url);
+        }
         chatEl.scrollTop = chatEl.scrollHeight;
         persist();
       }


### PR DESCRIPTION
## Summary
- Display reasoning block above message content by always prepending the reasoning element
- Restore assistant response streaming and remove pending state when tokens arrive

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b70b043e7c83219fdcacdbf3e40f4c