### PR TITLE
Restore assistant typing animation and reasoning placement

### DIFF
--- a/web/chat.js
+++ b/web/chat.js
@@ -32,11 +32,9 @@ export function appendReasoning(node, text){
   }
   const pre = block.querySelector('pre');
   pre.textContent += text;
-  if(node._textNode){
-    node.insertBefore(block, node._textNode);
-  }else{
-    node.prepend(block);
-  }
+  // Ensure reasoning block is always displayed above the generated content
+  // regardless of whether a text node already exists.
+  node.prepend(block);
 }
 
 export function renderAll(){
@@ -44,7 +42,10 @@ export function renderAll(){
   chatEl.innerHTML = '';
   const { messages } = store.sessions[store.currentId];
   for (const m of messages){
-    appendBubble(m.role, m.content);
+    const bubble = appendBubble(m.role, m.content);
+    if(m.role === 'assistant' && m.reasoning){
+      appendReasoning(bubble.querySelector('.content'), m.reasoning);
+    }
   }
   chatEl.scrollTop = chatEl.scrollHeight;
 }

--- a/web/main.js
+++ b/web/main.js
@@ -231,12 +231,17 @@ function escapeHtml(s){ return s.replace(/[&<>]/g, c=>({"&":"&amp;","<":"&lt;","
 
 // ====== 發送與串流 ======
 async function send(){ const text = inputEl.value.trim(); if(!text && !(store.ragEnabled && selected.size>0)) return; inputEl.value = '';
-  const sess = sessions[store.currentId]; if(text) { sess.messages.push({role:'user', content:text}); appendBubble('user', text); } persist(); const assistant = { role:'assistant', content:'' }; sess.messages.push(assistant); persist(); const bubble = appendBubble('assistant', ''); const contentEl = bubble.querySelector('.content');
+  const sess = sessions[store.currentId]; if(text) { sess.messages.push({role:'user', content:text}); appendBubble('user', text); } persist(); const assistant = { role:'assistant', content:'', reasoning:'' }; sess.messages.push(assistant); persist(); const bubble = appendBubble('assistant', ''); const contentEl = bubble.querySelector('.content');
+  function stopThinking(){
+    bubble.classList.remove('pending');
+    const loader = contentEl.querySelector('.loader');
+    if(loader) loader.remove();
+  }
   // 在這一輪對話綁定停止鍵，能移除等待動畫
   const prevStopHandler = stopBtn.onclick;
   stopBtn.onclick = () => {
     if(controller){ controller.abort(); stopBtn.disabled = true; }
-    bubble.classList.remove('pending');
+    stopThinking();
     if(!assistant.content){
       assistant.content = '[已停止]';
       contentEl._textNode.textContent = assistant.content;
@@ -257,11 +262,21 @@ async function send(){ const text = inputEl.value.trim(); if(!text && !(store.ra
         if(dataStr==='[DONE]') return;
         let obj;
         try{ obj = JSON.parse(dataStr); }
+        catch{ obj = { data: dataStr }; }
+        if(typeof obj.data === 'string' && (obj.type === 'text' || !obj.type)){
+          assistant.content += obj.data;
+          contentEl._textNode.textContent = assistant.content;
+          stopThinking();
           chatEl.scrollTop = chatEl.scrollHeight;
           persist();
         }else if(obj.type === 'reasoning'){
           appendReasoning(contentEl, obj.data);
+          assistant.reasoning += obj.data;
+          persist();
         }else if(typeof obj.token === 'string'){
+          assistant.content += obj.token;
+          contentEl._textNode.textContent = assistant.content;
+          stopThinking();
           chatEl.scrollTop = chatEl.scrollHeight;
           persist();
         }
@@ -273,12 +288,13 @@ async function send(){ const text = inputEl.value.trim(); if(!text && !(store.ra
           const url = new URL(location.href);
           url.searchParams.set('threadId', obj.thread_id);
           history.replaceState(null, '', url);
+        }
         chatEl.scrollTop = chatEl.scrollHeight;
         persist();
       }
     }
     while(true){ const {value, done} = await reader.read(); buffer += decoder.decode(value || new Uint8Array(), {stream: !done}); await flush(done); if(done) break; }
-  }catch(err){ assistant.content += `\n[error] ${err?.message||err}`; contentEl._textNode.textContent = assistant.content; } finally { sendBtn.disabled = false; stopBtn.disabled = true; controller = null; bubble.classList.remove('pending'); persist(); }
+  }catch(err){ assistant.content += `\n[error] ${err?.message||err}`; contentEl._textNode.textContent = assistant.content; } finally { sendBtn.disabled = false; stopBtn.disabled = true; controller = null; stopThinking(); persist(); }
 }
 
 function buildPayload(msgs, lastUserText){


### PR DESCRIPTION
## Summary
- Persist assistant reasoning text and render it after refresh
- Stop the thinking animation once content tokens stream in

## Testing
- `node --check web/main.js`
- `node --check web/chat.js`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b70b043e7c83219fdcacdbf3e40f4c