### PR TITLE
Keep loader visible until first streamed token

### DIFF
--- a/web/main.js
+++ b/web/main.js
@@ -231,7 +231,15 @@ function escapeHtml(s){ return s.replace(/[&<>]/g, c=>({"&":"&amp;","<":"&lt;","
 
 // ====== 發送與串流 ======
 async function send(){ const text = inputEl.value.trim(); if(!text && !(store.ragEnabled && selected.size>0)) return; inputEl.value = '';
-  const sess = sessions[store.currentId]; if(text) { sess.messages.push({role:'user', content:text}); appendBubble('user', text); } persist(); const assistant = { role:'assistant', content:'', reasoning:'' }; sess.messages.push(assistant); persist(); const bubble = appendBubble('assistant', ''); const contentEl = bubble.querySelector('.content');
+  const sess = sessions[store.currentId];
+  if(text) { sess.messages.push({role:'user', content:text}); appendBubble('user', text); }
+  persist();
+  const assistant = { role:'assistant', content:'', reasoning:'' };
+  sess.messages.push(assistant);
+  persist();
+  const bubble = appendBubble('assistant', '');
+  const contentEl = bubble.querySelector('.content');
+  let hasStarted = false;
   function stopThinking(){
     bubble.classList.remove('pending');
     const loader = contentEl.querySelector('.loader');
@@ -263,23 +271,20 @@ async function send(){ const text = inputEl.value.trim(); if(!text && !(store.ra
         let obj;
         try{ obj = JSON.parse(dataStr); }
         catch{ obj = { data: dataStr }; }
-        if(typeof obj.data === 'string' && (obj.type === 'text' || !obj.type)){
+        if(typeof obj.data === 'string' && obj.data && (obj.type === 'text' || !obj.type)){
           assistant.content += obj.data;
           contentEl._textNode.textContent = assistant.content;
-          stopThinking();
-          bubble.classList.remove('pending');
-
+          if(!hasStarted){ hasStarted = true; stopThinking(); }
           chatEl.scrollTop = chatEl.scrollHeight;
           persist();
         }else if(obj.type === 'reasoning'){
           appendReasoning(contentEl, obj.data);
           assistant.reasoning += obj.data;
           persist();
-        }else if(typeof obj.token === 'string'){
+        }else if(typeof obj.token === 'string' && obj.token){
           assistant.content += obj.token;
           contentEl._textNode.textContent = assistant.content;
-          stopThinking();
-          bubble.classList.remove('pending');
+          if(!hasStarted){ hasStarted = true; stopThinking(); }
           chatEl.scrollTop = chatEl.scrollHeight;
           persist();
         }


### PR DESCRIPTION
## Summary
- track streaming start in `web/main.js` with a `hasStarted` flag
- remove spinner and `pending` class only after the first token arrives
- ignore empty `text` events so the loader isn't cleared by pre-stream pings

## Testing
- `npm run build` *(fails: Could not read package.json)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b71296d3908321b9bd134f26daec84