### PR TITLE
feat(web): add knowledge base management page

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -13,6 +13,7 @@
       <div class="side-top">
         <button id="newBtn">＋ 新對話</button>
         <button class="ghost" id="exportBtn">匯出</button>
+        <a class="ghost" id="kbLink" href="kb.html">知識庫管理</a>
       </div>
       <div class="side-scroll" id="convList"></div>
       <div class="footer-note">本機儲存：<span class="muted">localStorage</span></div>

--- a/web/kb.html
+++ b/web/kb.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="zh-Hant">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>知識庫管理</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>知識庫管理</h1>
+  <form id="uploadForm">
+    <input type="text" id="title" placeholder="標題" required />
+    <input type="text" id="source" placeholder="來源" required />
+    <input type="file" id="file" required />
+    <button type="submit">上傳</button>
+  </form>
+  <table class="kb-list">
+    <thead>
+      <tr><th>標題</th><th>來源</th><th>操作</th></tr>
+    </thead>
+    <tbody id="docTable"></tbody>
+  </table>
+  <script type="module" src="kb.js"></script>
+</body>
+</html>

--- a/web/kb.js
+++ b/web/kb.js
@@ -1,0 +1,53 @@
+async function loadDocs(){
+  try{
+    const res = await fetch('/docs/list');
+    const data = await res.json();
+    const tbody = document.getElementById('docTable');
+    tbody.innerHTML = '';
+    (data.docs || []).forEach(d => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td>${d.title||''}</td><td>${d.source||''}</td><td><button onclick="editDoc('${d.id}')">編輯</button> <button onclick="deleteDoc('${d.id}')">刪除</button></td>`;
+      tbody.appendChild(tr);
+    });
+  }catch(e){ console.error('loadDocs error', e); }
+}
+
+async function uploadDoc(ev){
+  ev.preventDefault();
+  const title = document.getElementById('title').value.trim();
+  const source = document.getElementById('source').value.trim();
+  const file = document.getElementById('file').files[0];
+  if(!file) return;
+  const text = await file.text();
+  await fetch('/docs/save', {
+    method:'POST',
+    headers:{'Content-Type':'application/json'},
+    body: JSON.stringify({ title, content:text, metadata:{ source } })
+  });
+  ev.target.reset();
+  loadDocs();
+}
+
+async function editDoc(id){
+  const title = prompt('新標題?');
+  if(title===null) return;
+  const source = prompt('新來源?');
+  if(source===null) return;
+  await fetch(`/docs/${id}`, {
+    method:'PUT',
+    headers:{'Content-Type':'application/json'},
+    body: JSON.stringify({ title, source })
+  });
+  loadDocs();
+}
+
+async function deleteDoc(id){
+  if(!confirm('確定刪除？')) return;
+  await fetch(`/docs/${id}`, { method:'DELETE' });
+  loadDocs();
+}
+
+document.getElementById('uploadForm').addEventListener('submit', uploadDoc);
+window.editDoc = editDoc;
+window.deleteDoc = deleteDoc;
+loadDocs();


### PR DESCRIPTION
## Summary
- add knowledge base management page with upload, edit, and delete controls
- implement front-end API calls for document management
- link chat sidebar to knowledge base management page

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8fc39705c8321bb63c3ab4bb1a50c