### PR TITLE
Add document management routes and helpers

### DIFF
--- a/api/routes/kb.py
+++ b/api/routes/kb.py
@@ -12,6 +12,7 @@ from ..app import (
     content_hash,
     _slug,
     _index_doc_to_stores,
+    _delete_doc_from_stores,
     upsert_kb_item,
     search_kb_fts,
     _query_chroma,
@@ -21,6 +22,92 @@ from ..app import (
 )
 
 router = APIRouter()
+
+
+def _find_doc(doc_id: str):
+    for fp in Path(DOCS_DIR).rglob("*.json"):
+        try:
+            data = json.loads(fp.read_text("utf-8"))
+        except Exception:
+            continue
+        if data.get("id") == doc_id:
+            return fp, data
+    return None, None
+
+
+@router.get("/docs/list")
+def docs_list(api_key: Optional[str] = Security(api_key_header)):
+    _auth(api_key)
+    docs = []
+    if not Path(DOCS_DIR).exists():
+        return {"docs": docs}
+    for fp in Path(DOCS_DIR).rglob("*.json"):
+        try:
+            data = json.loads(fp.read_text("utf-8"))
+            docs.append({
+                "id": data.get("id"),
+                "title": data.get("title"),
+                "metadata": data.get("metadata") or {},
+            })
+        except Exception:
+            continue
+    docs.sort(key=lambda x: x.get("metadata", {}).get("updated_ts", 0), reverse=True)
+    return {"docs": docs}
+
+
+@router.get("/docs/{doc_id}")
+def docs_get(doc_id: str, api_key: Optional[str] = Security(api_key_header)):
+    _auth(api_key)
+    path, data = _find_doc(doc_id)
+    if not data:
+        raise HTTPException(404, "doc not found")
+    return data
+
+
+@router.put("/docs/{doc_id}")
+def docs_put(doc_id: str, item: SaveDocItem, background_tasks: BackgroundTasks, api_key: Optional[str] = Security(api_key_header)):
+    _auth(api_key)
+    path, old = _find_doc(doc_id)
+    if not old:
+        raise HTTPException(404, "doc not found")
+
+    now_ts = int(time.time())
+    src_key = item.metadata.get("source_key") if isinstance(item.metadata, dict) else None
+    if not src_key:
+        src_key = _slug(item.title)
+    c_hash = content_hash(item.content)
+
+    metadata = dict(item.metadata or {})
+    metadata.update({
+        "updated_ts": now_ts,
+        "source_key": src_key,
+        "content_hash": c_hash,
+    })
+
+    payload = {
+        "id": doc_id,
+        "title": item.title,
+        "content": item.content,
+        "metadata": metadata,
+    }
+
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), "utf-8")
+    old_src = (old.get("metadata") or {}).get("source_key")
+    background_tasks.add_task(_delete_doc_from_stores, doc_id, old_src)
+    background_tasks.add_task(_index_doc_to_stores, payload)
+    return {"ok": True, "id": doc_id, "file": path.name, "path": str(path)}
+
+
+@router.delete("/docs/{doc_id}")
+def docs_delete(doc_id: str, background_tasks: BackgroundTasks, api_key: Optional[str] = Security(api_key_header)):
+    _auth(api_key)
+    path, data = _find_doc(doc_id)
+    if not data:
+        raise HTTPException(404, "doc not found")
+    path.unlink()
+    src_key = (data.get("metadata") or {}).get("source_key")
+    background_tasks.add_task(_delete_doc_from_stores, doc_id, src_key)
+    return {"ok": True}
 
 
 @router.post("/docs/save")


### PR DESCRIPTION
## Summary
- add GET/PUT/DELETE routes for document management, including list
- implement vector store synchronization helpers for deleting docs
- ensure updated docs reindexed with metadata

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba90262e5c83219799cd5b6d19ad48