### PR TITLE
Expose document path info for folder tree

### DIFF
--- a/api/routes/kb.py
+++ b/api/routes/kb.py
@@ -41,13 +41,19 @@ def docs_list(api_key: Optional[str] = Security(api_key_header)):
     docs = []
     if not Path(DOCS_DIR).exists():
         return {"docs": docs}
-    for fp in Path(DOCS_DIR).rglob("*.json"):
+    base = Path(DOCS_DIR)
+    for fp in base.rglob("*.json"):
         try:
             data = json.loads(fp.read_text("utf-8"))
+            rel_path = fp.relative_to(base)
+            folder = str(rel_path.parent)
             docs.append({
                 "id": data.get("id"),
                 "title": data.get("title"),
                 "metadata": data.get("metadata") or {},
+                "path": str(rel_path),
+                "folder": folder,
+                "file": rel_path.name,
             })
         except Exception:
             continue

--- a/web/kb.js
+++ b/web/kb.js
@@ -8,7 +8,7 @@ async function loadDocs(q=''){
     const docs = data.docs || [];
     docs.forEach(d => {
       const tr = document.createElement('tr');
-      tr.innerHTML = `<td>${d.title||''}</td><td>${d.source||''}</td><td><button onclick="editDoc('${d.id}')">編輯</button> <button onclick="deleteDoc('${d.id}')">刪除</button></td>`;
+      tr.innerHTML = `<td>${d.title||''}</td><td>${d.file||d.source||''}</td><td><button onclick="editDoc('${d.id}')">編輯</button> <button onclick="deleteDoc('${d.id}')">刪除</button></td>`;
       tbody.appendChild(tr);
     });
     const treeDiv = document.getElementById('folderTree');
@@ -21,7 +21,7 @@ async function loadDocs(q=''){
 function buildTree(docs){
   const root = {};
   docs.forEach(d => {
-    const parts = (d.path || d.folder || '').split('/').filter(Boolean);
+    const parts = (d.folder || d.path || '').split('/').filter(Boolean);
     let node = root;
     parts.forEach(p => {
       node.children = node.children || {};
@@ -51,7 +51,7 @@ function renderTree(node, parent){
   if(node.docs){
     node.docs.forEach(d => {
       const li = document.createElement('li');
-      li.innerHTML = `${d.title||''} <span class="muted">${d.source||''}</span> <button onclick="editDoc('${d.id}')">編輯</button> <button onclick="deleteDoc('${d.id}')">刪除</button>`;
+      li.innerHTML = `${d.title||''} <span class="muted">${d.file||d.source||''}</span> <button onclick="editDoc('${d.id}')">編輯</button> <button onclick="deleteDoc('${d.id}')">刪除</button>`;
       ul.appendChild(li);
     });
   }


### PR DESCRIPTION
## Summary
- Include relative path, folder name and original filename in `/docs/list`
- Show file names and group documents by folders in knowledge base UI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68baa23a37b4832186164aaee75fbf27