### PR TITLE
Remove inline docModal display style

### DIFF
--- a/web/kb.html
+++ b/web/kb.html
@@ -27,7 +27,7 @@
     </thead>
     <tbody id="docTable"></tbody>
   </table>
-  <div id="docModal" style="display:none;">
+  <div id="docModal">
     <form id="docForm">
       <label>ID <input type="text" id="docId" /></label>
       <label>Namespace <input type="text" id="docNamespace" /></label>


### PR DESCRIPTION
## Summary
- remove inline `style="display:none;"` from `docModal`
- ensure modal visibility controlled via CSS `show` class

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfa32ca1e083218248b830774ac9b2