### PR TITLE
feat: add JSON tree editor for doc body

### DIFF
--- a/web/kb.html
+++ b/web/kb.html
@@ -34,7 +34,7 @@
       <label>Type <input type="text" id="docType" /></label>
       <label>Title <input type="text" id="docTitle" /></label>
       <label>Summary <input type="text" id="docSummary" /></label>
-      <label>Body <textarea id="docBody"></textarea></label>
+      <label>Body <div id="docBodyEditor"></div></label>
       <label>Tags <input type="text" id="docTags" placeholder="tag1, tag2" /></label>
       <label>Canonicality <input type="text" id="docCanonicality" /></label>
       <label>Version <input type="text" id="docVersion" /></label>

--- a/web/styles.css
+++ b/web/styles.css
@@ -114,5 +114,12 @@ button.small{ padding:6px 10px; font-size:12px; border-radius:8px; }
 #docModal.show{display:flex;}
 #docModal form{background:var(--panel);padding:20px;border-radius:8px;max-width:600px;width:90%;max-height:90%;overflow:auto;display:flex;flex-direction:column;gap:8px;}
 #docModal label{display:flex;flex-direction:column;font-size:14px;gap:4px;}
-#docModal textarea{min-height:120px;}
+#docModal #docBodyEditor{min-height:120px;}
+#docBodyEditor{border:1px solid var(--line);padding:8px;background:#0d1330;overflow:auto;}
+#docBodyEditor .tree-object,#docBodyEditor .tree-array{margin-left:16px;border-left:1px dashed var(--line);padding-left:8px;}
+#docBodyEditor .tree-row{display:flex;align-items:center;gap:6px;margin:4px 0;}
+#docBodyEditor .tree-key{width:120px;}
+#docBodyEditor .tree-add{background:var(--brand-2);color:#052018;padding:2px 6px;border-radius:6px;}
+#docBodyEditor .tree-remove{background:var(--danger);color:#fff;padding:2px 6px;border-radius:6px;}
+#docBodyEditor input{background:#0d1330;color:var(--text);border:1px solid var(--line);border-radius:6px;padding:2px 4px;}
 /* --- End modal --- */


### PR DESCRIPTION
## Summary
- replace textarea with container for document body editing
- implement recursive tree editor for JSON document bodies with add/remove support
- serialize edited tree back into doc body and style the tree editor

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfadfd05c0832180096322d8889e8b