### PR TITLE
feat(web): add tree editing controls

### DIFF
--- a/web/kb.js
+++ b/web/kb.js
@@ -83,8 +83,8 @@ function renderObject(obj){
   });
   const addBtn = document.createElement('button');
   addBtn.type = 'button';
-  addBtn.textContent = '+';
-  addBtn.className = 'tree-add';
+  addBtn.textContent = '增加下層';
+  addBtn.className = 'tree-add-child';
   addBtn.onclick = () => div.insertBefore(renderObjectRow('', ''), addBtn);
   div.appendChild(addBtn);
   return div;
@@ -93,18 +93,23 @@ function renderObject(obj){
 function renderObjectRow(key, value){
   const row = document.createElement('div');
   row.className = 'tree-row';
-  const keyInput = document.createElement('input');
-  keyInput.className = 'tree-key';
-  keyInput.value = key;
+  const keyLabel = document.createElement('span');
+  keyLabel.className = 'tree-label';
+  keyLabel.textContent = key;
   const valDiv = document.createElement('div');
   valDiv.className = 'tree-value';
   valDiv.appendChild(renderValue(value));
+  const addBtn = document.createElement('button');
+  addBtn.type = 'button';
+  addBtn.textContent = '增加下層';
+  addBtn.className = 'tree-add-child';
+  addBtn.onclick = () => addChild(valDiv);
   const rmBtn = document.createElement('button');
   rmBtn.type = 'button';
-  rmBtn.textContent = '-';
+  rmBtn.textContent = '刪除';
   rmBtn.className = 'tree-remove';
   rmBtn.onclick = () => row.remove();
-  row.append(keyInput, valDiv, rmBtn);
+  row.append(keyLabel, valDiv, addBtn, rmBtn);
   return row;
 }
 
@@ -115,8 +120,8 @@ function renderArray(arr){
   arr.forEach(v => div.appendChild(renderArrayRow(v)));
   const addBtn = document.createElement('button');
   addBtn.type = 'button';
-  addBtn.textContent = '+';
-  addBtn.className = 'tree-add';
+  addBtn.textContent = '增加下層';
+  addBtn.className = 'tree-add-child';
   addBtn.onclick = () => div.insertBefore(renderArrayRow(''), addBtn);
   div.appendChild(addBtn);
   return div;
@@ -128,21 +133,43 @@ function renderArrayRow(value){
   const valDiv = document.createElement('div');
   valDiv.className = 'tree-value';
   valDiv.appendChild(renderValue(value));
+  const addBtn = document.createElement('button');
+  addBtn.type = 'button';
+  addBtn.textContent = '增加下層';
+  addBtn.className = 'tree-add-child';
+  addBtn.onclick = () => addChild(valDiv);
   const rmBtn = document.createElement('button');
   rmBtn.type = 'button';
-  rmBtn.textContent = '-';
+  rmBtn.textContent = '刪除';
   rmBtn.className = 'tree-remove';
   rmBtn.onclick = () => row.remove();
-  row.append(valDiv, rmBtn);
+  row.append(valDiv, addBtn, rmBtn);
   return row;
 }
 
 function renderPrimitive(value){
-  const input = document.createElement('input');
-  input.className = 'tree-primitive';
-  input.dataset.type = 'primitive';
-  input.value = value;
-  return input;
+  const span = document.createElement('span');
+  span.className = 'tree-label';
+  span.dataset.type = 'primitive';
+  span.textContent = value;
+  return span;
+}
+
+function addChild(container){
+  const node = container.firstElementChild;
+  if(!node){
+    container.appendChild(renderObject({}));
+    return;
+  }
+  if(node.dataset.type === 'object'){
+    node.insertBefore(renderObjectRow('', ''), node.lastElementChild);
+  }else if(node.dataset.type === 'array'){
+    node.insertBefore(renderArrayRow(''), node.lastElementChild);
+  }else{
+    const obj = renderObject({});
+    container.innerHTML = '';
+    container.appendChild(obj);
+  }
 }
 
 function editorToJson(){
@@ -157,7 +184,7 @@ function readValue(node){
     const obj = {};
     Array.from(node.children).forEach(ch => {
       if(!ch.classList.contains('tree-row')) return;
-      const key = ch.querySelector('.tree-key').value;
+      const key = ch.querySelector('.tree-label')?.textContent || '';
       const valNode = ch.querySelector('.tree-value').firstElementChild;
       if(key) obj[key] = readValue(valNode);
     });
@@ -171,7 +198,7 @@ function readValue(node){
     });
     return arr;
   }else{
-    const val = node.value.trim();
+    const val = node.textContent.trim();
     if(val === '') return '';
     try{ return JSON.parse(val); }
     catch{ return val; }

--- a/web/styles.css
+++ b/web/styles.css
@@ -117,9 +117,8 @@ button.small{ padding:6px 10px; font-size:12px; border-radius:8px; }
 #docModal #docBodyEditor{min-height:120px;}
 #docBodyEditor{border:1px solid var(--line);padding:8px;background:#0d1330;overflow:auto;}
 #docBodyEditor .tree-object,#docBodyEditor .tree-array{margin-left:16px;border-left:1px dashed var(--line);padding-left:8px;}
-#docBodyEditor .tree-row{display:flex;align-items:center;gap:6px;margin:4px 0;}
-#docBodyEditor .tree-key{width:120px;}
-#docBodyEditor .tree-add{background:var(--brand-2);color:#052018;padding:2px 6px;border-radius:6px;}
-#docBodyEditor .tree-remove{background:var(--danger);color:#fff;padding:2px 6px;border-radius:6px;}
-#docBodyEditor input{background:#0d1330;color:var(--text);border:1px solid var(--line);border-radius:6px;padding:2px 4px;}
+#docBodyEditor .tree-row{display:flex;align-items:center;gap:8px;margin:4px 0;padding-left:8px;}
+#docBodyEditor .tree-label,#docBodyEditor .tree-add-child,#docBodyEditor .tree-remove{border:1px solid var(--line);border-radius:9999px;padding:2px 6px;}
+#docBodyEditor .tree-add-child{background:var(--brand-2);color:#052018;}
+#docBodyEditor .tree-remove{background:var(--danger);color:#fff;}
 /* --- End modal --- */


### PR DESCRIPTION
## Summary
- replace editable inputs with span tree-labels and add add-child/remove buttons for each node
- update object/array renderers and primitive handling to support new controls
- style tree rows and capsule-like action buttons

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfb433eb748321a2000ce3a98acc2b