### PR TITLE
refactor: improve doc modal layout

### DIFF
--- a/web/kb.html
+++ b/web/kb.html
@@ -29,15 +29,17 @@
   </table>
   <div id="docModal">
     <form id="docForm">
-      <label>ID <input type="text" id="docId" /></label>
-      <label>Namespace <input type="text" id="docNamespace" /></label>
-      <label>Type <input type="text" id="docType" /></label>
-      <label>Title <input type="text" id="docTitle" /></label>
-      <label>Summary <input type="text" id="docSummary" /></label>
-      <label>Body <div id="docBodyEditor"></div></label>
-      <label>Tags <input type="text" id="docTags" placeholder="tag1, tag2" /></label>
-      <label>Canonicality <input type="text" id="docCanonicality" /></label>
-      <label>Version <input type="text" id="docVersion" /></label>
+      <label class="full">Title <input type="text" id="docTitle" /></label>
+      <label class="full">Summary <input type="text" id="docSummary" /></label>
+      <label class="full">Body <div id="docBodyEditor"></div></label>
+      <div class="meta">
+        <label>ID <input type="text" id="docId" /></label>
+        <label>Namespace <input type="text" id="docNamespace" /></label>
+        <label>Type <input type="text" id="docType" /></label>
+        <label>Version <input type="text" id="docVersion" /></label>
+        <label>Tags <input type="text" id="docTags" placeholder="tag1, tag2" /></label>
+        <label>Canonicality <input type="text" id="docCanonicality" /></label>
+      </div>
       <div class="actions">
         <button type="button" onclick="saveDoc()">Save</button>
         <button type="button" onclick="hideDocModal()">Cancel</button>

--- a/web/styles.css
+++ b/web/styles.css
@@ -112,7 +112,31 @@ button.small{ padding:6px 10px; font-size:12px; border-radius:8px; }
 /* --- Simple modal --- */
 #docModal{position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,.6);display:none;justify-content:center;align-items:center;}
 #docModal.show{display:flex;}
-#docModal form{background:var(--panel);padding:20px;border-radius:8px;max-width:600px;width:90%;max-height:90%;overflow:auto;display:flex;flex-direction:column;gap:8px;}
+#docModal form{
+    background:var(--panel);
+    padding:20px;
+    border-radius:8px;
+    max-width:800px;
+    width:90%;
+    max-height:90%;
+    overflow:auto;
+    display:grid;
+    grid-template-columns:repeat(auto-fit,minmax(240px,1fr));
+    gap:12px;
+}
+#docModal form .full{grid-column:1/-1;}
+#docModal form .meta{
+    grid-column:1/-1;
+    display:grid;
+    grid-template-columns:repeat(auto-fit,minmax(240px,1fr));
+    gap:12px;
+}
+#docModal form .actions{
+    grid-column:1/-1;
+    display:flex;
+    gap:12px;
+    justify-content:flex-end;
+}
 #docModal label{display:flex;flex-direction:column;font-size:14px;gap:4px;}
 #docModal #docBodyEditor{min-height:120px;}
 #docBodyEditor{border:1px solid var(--line);padding:8px;background:#0d1330;overflow:auto;}


### PR DESCRIPTION
## Summary
- expand document modal form to max-width 800px and adopt responsive grid
- reorganize knowledge base modal fields into two-column grid with full-width long fields

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfb6db270c8321ba61d780a345100c