### PR TITLE
Expand tree editor button click targets

### DIFF
--- a/web/styles.css
+++ b/web/styles.css
@@ -142,7 +142,16 @@ button.small{ padding:6px 10px; font-size:12px; border-radius:8px; }
 #docBodyEditor{border:1px solid var(--line);padding:8px;background:#0d1330;overflow:auto;}
 #docBodyEditor .tree-object,#docBodyEditor .tree-array{margin-left:16px;border-left:1px dashed var(--line);padding-left:8px;}
 #docBodyEditor .tree-row{display:flex;align-items:center;gap:8px;margin:4px 0;padding-left:8px;}
-#docBodyEditor .tree-label,#docBodyEditor .tree-add-child,#docBodyEditor .tree-remove{border:1px solid var(--line);border-radius:9999px;padding:2px 6px;}
+#docBodyEditor .tree-label,
+#docBodyEditor .tree-add-child,
+#docBodyEditor .tree-remove{
+  border:1px solid var(--line);
+  border-radius:9999px;
+  padding:4px 8px;
+  display:inline-flex;
+  align-items:center;
+  cursor:pointer;
+}
 #docBodyEditor .tree-add-child{background:var(--brand-2);color:#052018;}
 #docBodyEditor .tree-remove{background:var(--danger);color:#fff;}
 /* --- End modal --- */


### PR DESCRIPTION
## Summary
- Enlarge `.tree-label`, `.tree-add-child`, and `.tree-remove` pills with inline-flex layout, centered alignment, pointer cursor, and wider padding.
- Confirmed tree editor rows still append buttons and labels as flex children for consistent spacing.

## Testing
- `pytest -q`
- ⚠️ `npm install -g jsdom` (403 Forbidden – unable to install test dependency)


------
https://chatgpt.com/codex/tasks/task_e_68bfb7ff13d48321afcb5d29b0a0ad16