### PR TITLE
Expand tree editor button click targets

### DIFF
--- a/web/kb.js
+++ b/web/kb.js
@@ -85,7 +85,10 @@ function renderObject(obj){
   addBtn.type = 'button';
   addBtn.textContent = '增加下層';
   addBtn.className = 'tree-add-child';
-  addBtn.onclick = () => div.insertBefore(renderObjectRow('', ''), addBtn);
+  addBtn.addEventListener('click', e => {
+    e.stopPropagation();
+    div.insertBefore(renderObjectRow('', ''), addBtn);
+  });
   div.appendChild(addBtn);
   return div;
 }
@@ -103,12 +106,18 @@ function renderObjectRow(key, value){
   addBtn.type = 'button';
   addBtn.textContent = '增加下層';
   addBtn.className = 'tree-add-child';
-  addBtn.onclick = () => addChild(valDiv);
+  addBtn.addEventListener('click', e => {
+    e.stopPropagation();
+    addChild(valDiv);
+  });
   const rmBtn = document.createElement('button');
   rmBtn.type = 'button';
   rmBtn.textContent = '刪除';
   rmBtn.className = 'tree-remove';
-  rmBtn.onclick = () => row.remove();
+  rmBtn.addEventListener('click', e => {
+    e.stopPropagation();
+    row.remove();
+  });
   row.append(keyLabel, valDiv, addBtn, rmBtn);
   return row;
 }
@@ -122,7 +131,10 @@ function renderArray(arr){
   addBtn.type = 'button';
   addBtn.textContent = '增加下層';
   addBtn.className = 'tree-add-child';
-  addBtn.onclick = () => div.insertBefore(renderArrayRow(''), addBtn);
+  addBtn.addEventListener('click', e => {
+    e.stopPropagation();
+    div.insertBefore(renderArrayRow(''), addBtn);
+  });
   div.appendChild(addBtn);
   return div;
 }
@@ -137,12 +149,18 @@ function renderArrayRow(value){
   addBtn.type = 'button';
   addBtn.textContent = '增加下層';
   addBtn.className = 'tree-add-child';
-  addBtn.onclick = () => addChild(valDiv);
+  addBtn.addEventListener('click', e => {
+    e.stopPropagation();
+    addChild(valDiv);
+  });
   const rmBtn = document.createElement('button');
   rmBtn.type = 'button';
   rmBtn.textContent = '刪除';
   rmBtn.className = 'tree-remove';
-  rmBtn.onclick = () => row.remove();
+  rmBtn.addEventListener('click', e => {
+    e.stopPropagation();
+    row.remove();
+  });
   row.append(valDiv, addBtn, rmBtn);
   return row;
 }
@@ -158,7 +176,9 @@ function renderPrimitive(value){
 function addChild(container){
   const node = container.firstElementChild;
   if(!node){
-    container.appendChild(renderObject({}));
+    const obj = renderObject({});
+    container.appendChild(obj);
+    obj.insertBefore(renderObjectRow('', ''), obj.lastElementChild);
     return;
   }
   if(node.dataset.type === 'object'){
@@ -169,6 +189,7 @@ function addChild(container){
     const obj = renderObject({});
     container.innerHTML = '';
     container.appendChild(obj);
+    obj.insertBefore(renderObjectRow('', ''), obj.lastElementChild);
   }
 }
 

--- a/web/styles.css
+++ b/web/styles.css
@@ -142,7 +142,16 @@ button.small{ padding:6px 10px; font-size:12px; border-radius:8px; }
 #docBodyEditor{border:1px solid var(--line);padding:8px;background:#0d1330;overflow:auto;}
 #docBodyEditor .tree-object,#docBodyEditor .tree-array{margin-left:16px;border-left:1px dashed var(--line);padding-left:8px;}
 #docBodyEditor .tree-row{display:flex;align-items:center;gap:8px;margin:4px 0;padding-left:8px;}
-#docBodyEditor .tree-label,#docBodyEditor .tree-add-child,#docBodyEditor .tree-remove{border:1px solid var(--line);border-radius:9999px;padding:2px 6px;}
+#docBodyEditor .tree-label,
+#docBodyEditor .tree-add-child,
+#docBodyEditor .tree-remove{
+  border:1px solid var(--line);
+  border-radius:9999px;
+  padding:4px 8px;
+  display:inline-flex;
+  align-items:center;
+  cursor:pointer;
+}
 #docBodyEditor .tree-add-child{background:var(--brand-2);color:#052018;}
 #docBodyEditor .tree-remove{background:var(--danger);color:#fff;}
 /* --- End modal --- */


### PR DESCRIPTION
## Summary
- Enlarge `.tree-label`, `.tree-add-child`, and `.tree-remove` pills with inline-flex layout, centered alignment, pointer cursor, and wider padding.
- Fix add-child logic to stop event bubbling and always insert a single placeholder row when converting primitives.

## Testing
- `pytest -q`
- ⚠️ `npm install jsdom` (403 Forbidden – unable to install dependency for DOM interaction test)


------
https://chatgpt.com/codex/tasks/task_e_68bfb7ff13d48321afcb5d29b0a0ad16