### PR TITLE
Expand tree editor button click targets

### DIFF
--- a/web/kb.js
+++ b/web/kb.js
@@ -85,7 +85,11 @@ function renderObject(obj){
   addBtn.type = 'button';
   addBtn.textContent = '增加下層';
   addBtn.className = 'tree-add-child';
-  addBtn.onclick = () => div.insertBefore(renderObjectRow('', ''), addBtn);
+  addBtn.addEventListener('click', e => {
+    e.preventDefault();
+    e.stopPropagation();
+    div.insertBefore(renderObjectRow('', ''), addBtn);
+  });
   div.appendChild(addBtn);
   return div;
 }
@@ -96,6 +100,7 @@ function renderObjectRow(key, value){
   const keyLabel = document.createElement('span');
   keyLabel.className = 'tree-label';
   keyLabel.textContent = key;
+  makeEditable(keyLabel);
   const valDiv = document.createElement('div');
   valDiv.className = 'tree-value';
   valDiv.appendChild(renderValue(value));
@@ -103,12 +108,20 @@ function renderObjectRow(key, value){
   addBtn.type = 'button';
   addBtn.textContent = '增加下層';
   addBtn.className = 'tree-add-child';
-  addBtn.onclick = () => addChild(valDiv);
+  addBtn.addEventListener('click', e => {
+    e.preventDefault();
+    e.stopPropagation();
+    const container = e.currentTarget.previousElementSibling;
+    addChild(container);
+  });
   const rmBtn = document.createElement('button');
   rmBtn.type = 'button';
   rmBtn.textContent = '刪除';
   rmBtn.className = 'tree-remove';
-  rmBtn.onclick = () => row.remove();
+  rmBtn.addEventListener('click', e => {
+    e.stopPropagation();
+    row.remove();
+  });
   row.append(keyLabel, valDiv, addBtn, rmBtn);
   return row;
 }
@@ -122,7 +135,11 @@ function renderArray(arr){
   addBtn.type = 'button';
   addBtn.textContent = '增加下層';
   addBtn.className = 'tree-add-child';
-  addBtn.onclick = () => div.insertBefore(renderArrayRow(''), addBtn);
+  addBtn.addEventListener('click', e => {
+    e.preventDefault();
+    e.stopPropagation();
+    div.insertBefore(renderArrayRow(''), addBtn);
+  });
   div.appendChild(addBtn);
   return div;
 }
@@ -137,12 +154,20 @@ function renderArrayRow(value){
   addBtn.type = 'button';
   addBtn.textContent = '增加下層';
   addBtn.className = 'tree-add-child';
-  addBtn.onclick = () => addChild(valDiv);
+  addBtn.addEventListener('click', e => {
+    e.preventDefault();
+    e.stopPropagation();
+    const container = e.currentTarget.previousElementSibling;
+    addChild(container);
+  });
   const rmBtn = document.createElement('button');
   rmBtn.type = 'button';
   rmBtn.textContent = '刪除';
   rmBtn.className = 'tree-remove';
-  rmBtn.onclick = () => row.remove();
+  rmBtn.addEventListener('click', e => {
+    e.stopPropagation();
+    row.remove();
+  });
   row.append(valDiv, addBtn, rmBtn);
   return row;
 }
@@ -152,13 +177,30 @@ function renderPrimitive(value){
   span.className = 'tree-label';
   span.dataset.type = 'primitive';
   span.textContent = value;
+  makeEditable(span);
   return span;
+}
+
+function makeEditable(el){
+  el.contentEditable = true;
+  el.addEventListener('click', e => {
+    e.stopPropagation();
+  });
+  el.addEventListener('keydown', e => {
+    e.stopPropagation();
+    if(e.key === 'Enter'){
+      e.preventDefault();
+      el.blur();
+    }
+  });
 }
 
 function addChild(container){
   const node = container.firstElementChild;
   if(!node){
-    container.appendChild(renderObject({}));
+    const obj = renderObject({});
+    container.appendChild(obj);
+    obj.insertBefore(renderObjectRow('', ''), obj.lastElementChild);
     return;
   }
   if(node.dataset.type === 'object'){
@@ -169,6 +211,7 @@ function addChild(container){
     const obj = renderObject({});
     container.innerHTML = '';
     container.appendChild(obj);
+    obj.insertBefore(renderObjectRow('', ''), obj.lastElementChild);
   }
 }
 

--- a/web/styles.css
+++ b/web/styles.css
@@ -142,7 +142,19 @@ button.small{ padding:6px 10px; font-size:12px; border-radius:8px; }
 #docBodyEditor{border:1px solid var(--line);padding:8px;background:#0d1330;overflow:auto;}
 #docBodyEditor .tree-object,#docBodyEditor .tree-array{margin-left:16px;border-left:1px dashed var(--line);padding-left:8px;}
 #docBodyEditor .tree-row{display:flex;align-items:center;gap:8px;margin:4px 0;padding-left:8px;}
-#docBodyEditor .tree-label,#docBodyEditor .tree-add-child,#docBodyEditor .tree-remove{border:1px solid var(--line);border-radius:9999px;padding:2px 6px;}
+#docBodyEditor .tree-label,
+#docBodyEditor .tree-add-child,
+#docBodyEditor .tree-remove{
+  border:1px solid var(--line);
+  border-radius:9999px;
+  padding:4px 8px;
+  display:inline-flex;
+  align-items:center;
+  cursor:pointer;
+}
+#docBodyEditor .tree-row .tree-label{flex:1;}
+#docBodyEditor .tree-row .tree-add-child,
+#docBodyEditor .tree-row .tree-remove{flex:0 0 auto;}
 #docBodyEditor .tree-add-child{background:var(--brand-2);color:#052018;}
 #docBodyEditor .tree-remove{background:var(--danger);color:#fff;}
 /* --- End modal --- */


### PR DESCRIPTION
## Summary
- Keep add-child operations scoped to the clicked row by resolving the target container from the button's previous sibling and preventing default click propagation
- Stop clicks on editable labels from bubbling to parent controls, avoiding accidental node insertion when releasing the mouse
- Ensure label spans flex to fill the row while add/remove pills stay fixed width for reliable hit areas

## Testing
- `pytest -q`
- `npm install jsdom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb7ff13d48321afcb5d29b0a0ad16