### PR TITLE
Expand tree editor button click targets

### DIFF
--- a/web/kb.js
+++ b/web/kb.js
@@ -12,7 +12,19 @@ async function loadDocs(q=''){
     const docs = data.docs || [];
     docs.forEach(d => {
       const tr = document.createElement('tr');
-      tr.innerHTML = `<td>${d.title||''}</td><td>${d.file||d.source||''}</td><td><button onclick="openEditModal('${d.id}')">編輯</button> <button onclick="deleteDoc('${d.id}')">刪除</button></td>`;
+      const titleTd = document.createElement('td');
+      titleTd.textContent = d.title || '';
+      const fileTd = document.createElement('td');
+      fileTd.textContent = d.file || d.source || '';
+      const actionsTd = document.createElement('td');
+      const editBtn = document.createElement('button');
+      editBtn.textContent = '編輯';
+      editBtn.addEventListener('click', function(){ openEditModal(d.id); });
+      const delBtn = document.createElement('button');
+      delBtn.textContent = '刪除';
+      delBtn.addEventListener('click', function(){ deleteDoc(d.id); });
+      actionsTd.append(editBtn, ' ', delBtn);
+      tr.append(titleTd, fileTd, actionsTd);
       tbody.appendChild(tr);
     });
     const treeDiv = document.getElementById('folderTree');
@@ -55,7 +67,18 @@ function renderTree(node, parent){
   if(node.docs){
     node.docs.forEach(d => {
       const li = document.createElement('li');
-      li.innerHTML = `${d.title||''} <span class="muted">${d.file||d.source||''}</span> <button onclick="openEditModal('${d.id}')">編輯</button> <button onclick="deleteDoc('${d.id}')">刪除</button>`;
+      const titleSpan = document.createElement('span');
+      titleSpan.textContent = d.title || '';
+      const fileSpan = document.createElement('span');
+      fileSpan.className = 'muted';
+      fileSpan.textContent = d.file || d.source || '';
+      const editBtn = document.createElement('button');
+      editBtn.textContent = '編輯';
+      editBtn.addEventListener('click', function(){ openEditModal(d.id); });
+      const delBtn = document.createElement('button');
+      delBtn.textContent = '刪除';
+      delBtn.addEventListener('click', function(){ deleteDoc(d.id); });
+      li.append(titleSpan, ' ', fileSpan, ' ', editBtn, ' ', delBtn);
       ul.appendChild(li);
     });
   }
@@ -85,7 +108,11 @@ function renderObject(obj){
   addBtn.type = 'button';
   addBtn.textContent = '增加下層';
   addBtn.className = 'tree-add-child';
-  addBtn.onclick = () => div.insertBefore(renderObjectRow('', ''), addBtn);
+  addBtn.addEventListener('click', e => {
+    e.preventDefault();
+    e.stopPropagation();
+    div.insertBefore(renderObjectRow('', ''), addBtn);
+  });
   div.appendChild(addBtn);
   return div;
 }
@@ -93,9 +120,11 @@ function renderObject(obj){
 function renderObjectRow(key, value){
   const row = document.createElement('div');
   row.className = 'tree-row';
-  const keyLabel = document.createElement('span');
+  const keyLabel = document.createElement('textarea');
   keyLabel.className = 'tree-label';
-  keyLabel.textContent = key;
+  keyLabel.value = key;
+  keyLabel.rows = 1;
+  makeEditable(keyLabel);
   const valDiv = document.createElement('div');
   valDiv.className = 'tree-value';
   valDiv.appendChild(renderValue(value));
@@ -103,12 +132,20 @@ function renderObjectRow(key, value){
   addBtn.type = 'button';
   addBtn.textContent = '增加下層';
   addBtn.className = 'tree-add-child';
-  addBtn.onclick = () => addChild(valDiv);
+  addBtn.addEventListener('click', e => {
+    e.preventDefault();
+    e.stopPropagation();
+    const container = e.currentTarget.previousElementSibling;
+    addChild(container);
+  });
   const rmBtn = document.createElement('button');
   rmBtn.type = 'button';
   rmBtn.textContent = '刪除';
   rmBtn.className = 'tree-remove';
-  rmBtn.onclick = () => row.remove();
+  rmBtn.addEventListener('click', e => {
+    e.stopPropagation();
+    row.remove();
+  });
   row.append(keyLabel, valDiv, addBtn, rmBtn);
   return row;
 }
@@ -122,7 +159,11 @@ function renderArray(arr){
   addBtn.type = 'button';
   addBtn.textContent = '增加下層';
   addBtn.className = 'tree-add-child';
-  addBtn.onclick = () => div.insertBefore(renderArrayRow(''), addBtn);
+  addBtn.addEventListener('click', e => {
+    e.preventDefault();
+    e.stopPropagation();
+    div.insertBefore(renderArrayRow(''), addBtn);
+  });
   div.appendChild(addBtn);
   return div;
 }
@@ -137,28 +178,56 @@ function renderArrayRow(value){
   addBtn.type = 'button';
   addBtn.textContent = '增加下層';
   addBtn.className = 'tree-add-child';
-  addBtn.onclick = () => addChild(valDiv);
+  addBtn.addEventListener('click', e => {
+    e.preventDefault();
+    e.stopPropagation();
+    const container = e.currentTarget.previousElementSibling;
+    addChild(container);
+  });
   const rmBtn = document.createElement('button');
   rmBtn.type = 'button';
   rmBtn.textContent = '刪除';
   rmBtn.className = 'tree-remove';
-  rmBtn.onclick = () => row.remove();
+  rmBtn.addEventListener('click', e => {
+    e.stopPropagation();
+    row.remove();
+  });
   row.append(valDiv, addBtn, rmBtn);
   return row;
 }
 
 function renderPrimitive(value){
-  const span = document.createElement('span');
-  span.className = 'tree-label';
-  span.dataset.type = 'primitive';
-  span.textContent = value;
-  return span;
+  const ta = document.createElement('textarea');
+  ta.className = 'tree-label';
+  ta.dataset.type = 'primitive';
+  ta.value = value;
+  ta.rows = 1;
+  makeEditable(ta);
+  return ta;
+}
+
+function makeEditable(el){
+  if(!(el instanceof HTMLTextAreaElement)){
+    el.contentEditable = true;
+  }
+  el.addEventListener('click', e => {
+    e.stopPropagation();
+  });
+  el.addEventListener('keydown', e => {
+    e.stopPropagation();
+    if(e.key === 'Enter' && !e.shiftKey){
+      e.preventDefault();
+      el.blur();
+    }
+  });
 }
 
 function addChild(container){
   const node = container.firstElementChild;
   if(!node){
-    container.appendChild(renderObject({}));
+    const obj = renderObject({});
+    container.appendChild(obj);
+    obj.insertBefore(renderObjectRow('', ''), obj.lastElementChild);
     return;
   }
   if(node.dataset.type === 'object'){
@@ -169,6 +238,7 @@ function addChild(container){
     const obj = renderObject({});
     container.innerHTML = '';
     container.appendChild(obj);
+    obj.insertBefore(renderObjectRow('', ''), obj.lastElementChild);
   }
 }
 
@@ -184,7 +254,8 @@ function readValue(node){
     const obj = {};
     Array.from(node.children).forEach(ch => {
       if(!ch.classList.contains('tree-row')) return;
-      const key = ch.querySelector('.tree-label')?.textContent || '';
+      const keyEl = ch.querySelector('.tree-label');
+      const key = keyEl ? (keyEl.tagName === 'TEXTAREA' ? keyEl.value.trim() : keyEl.textContent.trim()) : '';
       const valNode = ch.querySelector('.tree-value').firstElementChild;
       if(key) obj[key] = readValue(valNode);
     });
@@ -198,7 +269,7 @@ function readValue(node){
     });
     return arr;
   }else{
-    const val = node.textContent.trim();
+    const val = node.tagName === 'TEXTAREA' ? node.value.trim() : node.textContent.trim();
     if(val === '') return '';
     try{ return JSON.parse(val); }
     catch{ return val; }

--- a/web/styles.css
+++ b/web/styles.css
@@ -142,7 +142,26 @@ button.small{ padding:6px 10px; font-size:12px; border-radius:8px; }
 #docBodyEditor{border:1px solid var(--line);padding:8px;background:#0d1330;overflow:auto;}
 #docBodyEditor .tree-object,#docBodyEditor .tree-array{margin-left:16px;border-left:1px dashed var(--line);padding-left:8px;}
 #docBodyEditor .tree-row{display:flex;align-items:center;gap:8px;margin:4px 0;padding-left:8px;}
-#docBodyEditor .tree-label,#docBodyEditor .tree-add-child,#docBodyEditor .tree-remove{border:1px solid var(--line);border-radius:9999px;padding:2px 6px;}
+#docBodyEditor .tree-label{
+  border:1px solid var(--line);
+  border-radius:8px;
+  padding:4px 8px;
+  width:100%;
+  resize:vertical;
+  display:block;
+}
+#docBodyEditor .tree-add-child,
+#docBodyEditor .tree-remove{
+  border:1px solid var(--line);
+  border-radius:9999px;
+  padding:4px 8px;
+  display:inline-flex;
+  align-items:center;
+  cursor:pointer;
+}
+#docBodyEditor .tree-row .tree-label{flex:1;}
+#docBodyEditor .tree-row .tree-add-child,
+#docBodyEditor .tree-row .tree-remove{flex:0 0 auto;}
 #docBodyEditor .tree-add-child{background:var(--brand-2);color:#052018;}
 #docBodyEditor .tree-remove{background:var(--danger);color:#fff;}
 /* --- End modal --- */


### PR DESCRIPTION
## Summary
- Keep add-child operations scoped to the clicked row by resolving the target container from the button's previous sibling and preventing default click propagation
- Stop clicks on editable labels from bubbling to parent controls, avoiding accidental node insertion when releasing the mouse
- Ensure label spans flex to fill the row while add/remove pills stay fixed width for reliable hit areas
- Replace inline HTML event handlers with DOM-based listeners to eliminate syntax errors in `kb.js`

## Testing
- `pytest -q`
- `npm install -g jsdom` *(fails: 403 Forbidden – unable to install dependency for DOM interaction test)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb7ff13d48321afcb5d29b0a0ad16