### PR TITLE
Fix unmatched brace in kb editor

### DIFF
--- a/web/kb.js
+++ b/web/kb.js
@@ -220,19 +220,6 @@ function makeEditable(el){
       el.blur();
     }
   });
-
-function makeEditable(el){
-  el.contentEditable = true;
-  el.addEventListener('click', e => {
-    e.stopPropagation();
-  });
-  el.addEventListener('keydown', e => {
-    e.stopPropagation();
-    if(e.key === 'Enter'){
-      e.preventDefault();
-      el.blur();
-    }
-  });
 }
 
 function addChild(container){


### PR DESCRIPTION
## Summary
- close unbalanced `makeEditable` function in `kb.js`
- remove duplicated `makeEditable` definition

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfca76119c83219f3030b7917b20fd