### PR TITLE
Fix unmatched brace in kb editor

### DIFF
--- a/web/kb.js
+++ b/web/kb.js
@@ -207,21 +207,6 @@ function renderPrimitive(value){
 }
 
 function makeEditable(el){
-  if(!(el instanceof HTMLTextAreaElement)){
-    el.contentEditable = true;
-  }
-  el.addEventListener('click', e => {
-    e.stopPropagation();
-  });
-  el.addEventListener('keydown', e => {
-    e.stopPropagation();
-    if(e.key === 'Enter' && !e.shiftKey){
-      e.preventDefault();
-      el.blur();
-    }
-  });
-
-function makeEditable(el){
   el.contentEditable = true;
   el.addEventListener('click', e => {
     e.stopPropagation();


### PR DESCRIPTION
## Summary
- simplify `makeEditable` by dropping `HTMLTextAreaElement` checks

## Testing
- `node --check web/kb.js`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfca76119c83219f3030b7917b20fd